### PR TITLE
Fix typo in evdev-mouse.py

### DIFF
--- a/examples/evdev-mouse.py
+++ b/examples/evdev-mouse.py
@@ -23,7 +23,7 @@ Press Ctrl+C to exit!
 
 """)
 
-os.system('modprobe uninput')
+os.system('modprobe uinput')
 
 trackball = TrackBall(interrupt_pin=4)
 


### PR DESCRIPTION
Should read "uinput", not "uninput".